### PR TITLE
Updated image path to be relative to Python script

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,13 @@
+import os
 import json
 import urllib2
 from inky import InkyPHAT
 from PIL import Image, ImageFont, ImageDraw
 from font_fredoka_one import FredokaOne
+
+# Set current directory
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 # Load graphic
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from font_fredoka_one import FredokaOne
 
 # Load graphic
 
-img = Image.open("/home/pi/inky-hole/logo.png")
+img = Image.open("./logo.png")
 draw = ImageDraw.Draw(img)
 
 # get api data


### PR DESCRIPTION
A small update to allow the script to be placed in a different directory. I have various projects (including this one) stored in a sub-directory inside `/home/pi` so, the absolute path threw some errors when it couldn't locate the image. 

Thought this would make it a bit more flexible should anyone want to change the location of where the script lives.